### PR TITLE
This change was necessary to work on Leaflet v1.0.3

### DIFF
--- a/src/SelectLayers.js
+++ b/src/SelectLayers.js
@@ -56,7 +56,7 @@ L.Control.SelectLayers = L.Control.ActiveLayers.extend({
   ,_onBaseLayerOptionChange: function () {
     var selectedLayerIndex = this._baseLayersList.selectedIndex
     var selectedLayerOption = this._baseLayersList.options[selectedLayerIndex]
-    var selectedLayer = this._layers[selectedLayerOption.layerId]
+    var selectedLayer = this._layers[selectedLayerIndex]
 
     this._changeBaseLayer(selectedLayer)
   }


### PR DESCRIPTION
I don't fully understand what's going on, but by making this change I was able to get the layer selector to work with Leaflet 1.0.3, and Leaflet.ActiveLayers 0.3.0